### PR TITLE
[CA-5313] Change return type during signup when identifier is not verified and option forbidUnverifiedIdentifierLoginAfterSignup is enabled

### DIFF
--- a/src/main/java/co/reachfive/identity/sdk/demo/JavaMainActivity.java
+++ b/src/main/java/co/reachfive/identity/sdk/demo/JavaMainActivity.java
@@ -23,6 +23,7 @@ import co.reachfive.identity.sdk.core.models.AuthToken;
 import co.reachfive.identity.sdk.core.models.OpenIdUser;
 import co.reachfive.identity.sdk.core.models.SdkConfig;
 import co.reachfive.identity.sdk.core.models.requests.ProfileSignupRequest;
+import co.reachfive.identity.sdk.core.models.responses.SignupResponse;
 import co.reachfive.identity.sdk.facebook.FacebookProvider;
 import co.reachfive.identity.sdk.google.GoogleProvider;
 import co.reachfive.identity.sdk.webview.WebViewProvider;
@@ -103,7 +104,9 @@ public class JavaMainActivity extends AppCompatActivity {
             );
             reach5.signup(
                     signupRequest,
-                    this::handleLoginSuccess,
+                    success -> {
+                        showToast("test");
+                    },
                     failure -> {
                         Log.d(TAG, "signup error=" + failure.getMessage());
                         showToast("Signup With Password Error " + failure.getMessage());

--- a/src/main/java/co/reachfive/identity/sdk/demo/MainActivity.kt
+++ b/src/main/java/co/reachfive/identity/sdk/demo/MainActivity.kt
@@ -23,6 +23,7 @@ import co.reachfive.identity.sdk.core.models.requests.ProfileSignupRequest
 import co.reachfive.identity.sdk.core.models.requests.ProfileWebAuthnSignupRequest
 import co.reachfive.identity.sdk.core.models.requests.StartStepUpLoginFlow
 import co.reachfive.identity.sdk.core.models.requests.webAuthn.WebAuthnLoginRequest
+import co.reachfive.identity.sdk.core.models.responses.SignupResponse
 import co.reachfive.identity.sdk.demo.AuthenticatedActivity.Companion.AUTH_TOKEN
 import co.reachfive.identity.sdk.demo.AuthenticatedActivity.Companion.SDK_CONFIG
 import co.reachfive.identity.sdk.demo.databinding.*
@@ -188,7 +189,14 @@ class MainActivity : AppCompatActivity() {
             this.reach5.signup(
                 profile = signupRequest,
                 redirectUrl = redirectUrlBinding.text.toString().ifEmpty { null },
-                success = { handleLoginSuccess(it) },
+                success = {
+                    when(it) {
+                       is SignupResponse.AchievedLogin -> handleLoginSuccess(it.authToken)
+                       is SignupResponse.AwaitingIdentifierVerification -> {
+                           showToast("Signup occurred but awaiting identifier verification")
+                       }
+                    }
+                },
                 failure = {
                     Log.d(TAG, "signup error=$it")
                     showErrorToast(it)


### PR DESCRIPTION
https://reach5.atlassian.net/browse/CA-5313